### PR TITLE
Adjust CHB dataset loader for LaBraM pipeline compatibility

### DIFF
--- a/LaBraM-main/datasets/chb_dataset.py
+++ b/LaBraM-main/datasets/chb_dataset.py
@@ -33,7 +33,7 @@ class CustomDataset(Dataset):
     def collate(self, batch):
         x_data = np.array([x[0] for x in batch])
         y_label = np.array([x[1] for x in batch])
-        return to_tensor(x_data), to_tensor(y_label)
+        return to_tensor(x_data), to_tensor(y_label).long()
 
 
 class LoadDataset(object):
@@ -45,8 +45,10 @@ class LoadDataset(object):
         train_set = CustomDataset(self.datasets_dir, mode='train')
         val_set = CustomDataset(self.datasets_dir, mode='val')
         test_set = CustomDataset(self.datasets_dir, mode='test')
-        print(len(train_set), len(val_set), len(test_set))
-        print(len(train_set) + len(val_set) + len(test_set))
+        model_name = getattr(self.params, "model", "")
+        if isinstance(model_name, str) and "labram" in model_name.lower():
+            return train_set, val_set, test_set
+
         data_loader = {
             'train': DataLoader(
                 train_set,


### PR DESCRIPTION
## Summary
- ensure CHB classification labels are converted to integer tensors in the collate function
- allow the LaBraM pipeline to receive raw dataset splits while preserving legacy DataLoader behaviour
- remove noisy dataset length debug printing from the data loader setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fdd95ccc8330b3096c63c6bf2b8d