### PR TITLE
Add Labram fine-tuning support for Stress dataset

### DIFF
--- a/LaBraM-main/datasets/stress_dataset.py
+++ b/LaBraM-main/datasets/stress_dataset.py
@@ -45,6 +45,9 @@ class LoadDataset(object):
         train_set = CustomDataset(self.datasets_dir, mode='train')
         val_set = CustomDataset(self.datasets_dir, mode='val')
         test_set = CustomDataset(self.datasets_dir, mode='test')
+        if 'labram' in getattr(self.params, 'model', '').lower():
+            return train_set, val_set, test_set
+
         print(len(train_set), len(val_set), len(test_set))
         print(len(train_set)+len(val_set)+len(test_set))
         data_loader = {
@@ -58,13 +61,13 @@ class LoadDataset(object):
                 val_set,
                 batch_size=self.params.batch_size,
                 collate_fn=val_set.collate,
-                shuffle=True,
+                shuffle=False,
             ),
             'test': DataLoader(
                 test_set,
                 batch_size=self.params.batch_size,
                 collate_fn=test_set.collate,
-                shuffle=True,
+                shuffle=False,
             ),
         }
         return data_loader


### PR DESCRIPTION
## Summary
- allow the stress dataset loader to return raw datasets for LaBraM models and fix validation/test shuffling
- add channel normalization and metadata so the stress dataset can be used in the multidataset fine-tuning script
- register the stress dataset with the LaBraM fine-tuning workflow so BCE training and evaluation behave like other binary datasets

## Testing
- python -m compileall LaBraM-main/datasets/stress_dataset.py LaBraM-main/run_class_finetuning_multidata.py

------
https://chatgpt.com/codex/tasks/task_e_68eab85dff3883308a12a49cc2a62a99