### PR TITLE
Add imagined speech augmentations and mixup support

### DIFF
--- a/LaBraM-main/datasets/speech_dataset.py
+++ b/LaBraM-main/datasets/speech_dataset.py
@@ -7,16 +7,106 @@ import random
 import lmdb
 import pickle
 
+class SpeechAugmentor:
+    """Applies lightweight stochastic augmentations for imagined-speech EEG."""
+
+    def __init__(
+        self,
+        jitter_std: float = 0.0,
+        jitter_prob: float = 0.0,
+        time_shift_prob: float = 0.0,
+        time_shift_max_pct: float = 0.0,
+        channel_dropout_prob: float = 0.0,
+        channel_dropout_max_pct: float = 0.0,
+    ) -> None:
+        self.jitter_std = max(0.0, float(jitter_std))
+        self.jitter_prob = max(0.0, float(jitter_prob))
+        self.time_shift_prob = max(0.0, float(time_shift_prob))
+        self.time_shift_max_pct = max(0.0, float(time_shift_max_pct))
+        self.channel_dropout_prob = max(0.0, float(channel_dropout_prob))
+        self.channel_dropout_max_pct = max(0.0, float(channel_dropout_max_pct))
+
+    def _maybe_apply_jitter(self, data: np.ndarray) -> np.ndarray:
+        if self.jitter_prob <= 0.0 or self.jitter_std <= 0.0:
+            return data
+        if random.random() >= self.jitter_prob:
+            return data
+        noise_scale = np.std(data, axis=-1, keepdims=True)
+        noise_scale = np.maximum(noise_scale, 1e-6)
+        noise_scale = noise_scale.astype(data.dtype, copy=False)
+        noise = np.random.normal(loc=0.0, scale=self.jitter_std, size=data.shape).astype(data.dtype, copy=False)
+        return data + noise * noise_scale
+
+    def _maybe_apply_time_shift(self, data: np.ndarray) -> np.ndarray:
+        if self.time_shift_prob <= 0.0 or self.time_shift_max_pct <= 0.0:
+            return data
+        if random.random() >= self.time_shift_prob:
+            return data
+        time_len = data.shape[-1]
+        max_shift = int(self.time_shift_max_pct * time_len)
+        if max_shift <= 0:
+            return data
+        shift = random.randint(-max_shift, max_shift)
+        if shift == 0:
+            return data
+        return np.roll(data, shift=shift, axis=-1)
+
+    def _maybe_apply_channel_dropout(self, data: np.ndarray) -> np.ndarray:
+        if self.channel_dropout_prob <= 0.0 or self.channel_dropout_max_pct <= 0.0:
+            return data
+        if data.ndim < 2 or random.random() >= self.channel_dropout_prob:
+            return data
+        num_channels = data.shape[0]
+        drop_count = max(1, int(round(self.channel_dropout_max_pct * num_channels)))
+        drop_count = min(drop_count, num_channels)
+        if drop_count <= 0:
+            return data
+        drop_idx = np.random.choice(num_channels, size=drop_count, replace=False)
+        data = data.copy()
+        data[drop_idx, ...] = 0.0
+        return data
+
+    def __call__(self, sample: np.ndarray) -> np.ndarray:
+        augmented = np.array(sample, copy=True)
+        augmented = self._maybe_apply_time_shift(augmented)
+        augmented = self._maybe_apply_channel_dropout(augmented)
+        augmented = self._maybe_apply_jitter(augmented)
+        return augmented
+
+
+def _build_speech_augmentor(params):
+    jitter_std = getattr(params, 'speech_jitter_std', 0.0)
+    jitter_prob = getattr(params, 'speech_jitter_prob', 0.0)
+    time_shift_prob = getattr(params, 'speech_time_shift_prob', 0.0)
+    time_shift_pct = getattr(params, 'speech_time_shift_pct', 0.0)
+    channel_drop_prob = getattr(params, 'speech_channel_dropout_prob', 0.0)
+    channel_drop_pct = getattr(params, 'speech_channel_dropout_max_pct', 0.0)
+
+    if max(jitter_std, jitter_prob, time_shift_prob, time_shift_pct, channel_drop_prob, channel_drop_pct) <= 0:
+        return None
+
+    return SpeechAugmentor(
+        jitter_std=jitter_std,
+        jitter_prob=jitter_prob,
+        time_shift_prob=time_shift_prob,
+        time_shift_max_pct=time_shift_pct,
+        channel_dropout_prob=channel_drop_prob,
+        channel_dropout_max_pct=channel_drop_pct,
+    )
+
+
 class CustomDataset(Dataset):
     def __init__(
             self,
             data_dir,
             mode='train',
+            augmentor=None,
     ):
         super(CustomDataset, self).__init__()
         self.db = lmdb.open(data_dir, readonly=True, lock=False, readahead=True, meminit=False)
         with self.db.begin(write=False) as txn:
             self.keys = pickle.loads(txn.get('__keys__'.encode()))[mode]
+        self.augmentor = augmentor if mode == 'train' else None
 
     def __len__(self):
         return len((self.keys))
@@ -26,6 +116,8 @@ class CustomDataset(Dataset):
         with self.db.begin(write=False) as txn:
             pair = pickle.loads(txn.get(key.encode()))
         data = pair['sample']
+        if self.augmentor is not None:
+            data = self.augmentor(data)
         label =  int(pair['label'])
         # print(key)
         # print(data.shape)
@@ -43,7 +135,8 @@ class LoadDataset(object):
         self.datasets_dir = params.datasets_dir
 
     def get_data_loader(self):
-        train_set = CustomDataset(self.datasets_dir, mode='train')
+        augmentor = _build_speech_augmentor(self.params)
+        train_set = CustomDataset(self.datasets_dir, mode='train', augmentor=augmentor)
         val_set = CustomDataset(self.datasets_dir, mode='val')
         test_set = CustomDataset(self.datasets_dir, mode='test')
         if 'labram' in getattr(self.params, 'model', '').lower():

--- a/LaBraM-main/run_class_finetuning_multidata.py
+++ b/LaBraM-main/run_class_finetuning_multidata.py
@@ -148,6 +148,30 @@ def get_args():
     parser.add_argument('--fixed_chkpt', default='',
                         help='path for fixed checkpoint for evaluation or continue')
 
+    # Augmentation parameters
+    parser.add_argument('--mixup', type=float, default=0.0,
+                        help='mixup alpha, set >0 to enable mixup')
+    parser.add_argument('--cutmix', type=float, default=0.0,
+                        help='cutmix alpha, set >0 to enable cutmix')
+    parser.add_argument('--mixup_prob', type=float, default=1.0,
+                        help='probability of applying mixup or cutmix')
+    parser.add_argument('--mixup_switch_prob', type=float, default=0.5,
+                        help='probability of switching between mixup and cutmix when both enabled')
+    parser.add_argument('--mixup_mode', type=str, default='batch',
+                        help='how to apply mixup/cutmix (batch, pair, elem)')
+    parser.add_argument('--speech_jitter_std', type=float, default=0.0,
+                        help='relative std-dev for Gaussian jitter noise (× channel std)')
+    parser.add_argument('--speech_jitter_prob', type=float, default=0.0,
+                        help='probability of applying jitter noise per sample')
+    parser.add_argument('--speech_time_shift_pct', type=float, default=0.0,
+                        help='max absolute time shift as a fraction of window length (e.g. 0.1 = 10%)')
+    parser.add_argument('--speech_time_shift_prob', type=float, default=0.0,
+                        help='probability of applying time shift per sample')
+    parser.add_argument('--speech_channel_dropout_prob', type=float, default=0.0,
+                        help='probability of dropping random channels per sample')
+    parser.add_argument('--speech_channel_dropout_max_pct', type=float, default=0.0,
+                        help='max fraction of channels to zero out during dropout')
+
     parser.add_argument('--log_dir', default=None,
                         help='path where to tensorboard log')
     parser.add_argument('--device', default='cuda',
@@ -1029,6 +1053,19 @@ def main(args, ds_init):
         args.weight_decay, args.weight_decay_end, args.epochs, num_training_steps_per_epoch)
     print("Max WD = %.7f, Min WD = %.7f" % (max(wd_schedule_values), min(wd_schedule_values)))
 
+    mixup_fn = None
+    mixup_active = (args.mixup > 0.0 or args.cutmix > 0.0) and args.nb_classes > 1
+    if mixup_active:
+        mixup_fn = Mixup(
+            mixup_alpha=args.mixup,
+            cutmix_alpha=args.cutmix,
+            prob=args.mixup_prob,
+            switch_prob=args.mixup_switch_prob,
+            mode=args.mixup_mode,
+            label_smoothing=args.smoothing if args.smoothing > 0 else 0.0,
+            num_classes=args.nb_classes,
+        )
+
     if args.nb_classes == 1:
         pos_weight_tensor = None
         if args.pos_weight is not None:
@@ -1037,6 +1074,8 @@ def main(args, ds_init):
         else:
             print("Using BCEWithLogitsLoss without pos_weight; consider setting --pos_weight=N_neg/N_pos for imbalanced splits")
         criterion = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight_tensor)
+    elif mixup_active:
+        criterion = SoftTargetCrossEntropy()
     elif args.smoothing > 0.:
         criterion = LabelSmoothingCrossEntropy(smoothing=args.smoothing)
     else:
@@ -1118,8 +1157,9 @@ def main(args, ds_init):
             device, epoch, loss_scaler, args.clip_grad, model_ema,
             log_writer=log_writer, start_steps=epoch * num_training_steps_per_epoch,
             lr_schedule_values=lr_schedule_values, wd_schedule_values=wd_schedule_values,
-            num_training_steps_per_epoch=num_training_steps_per_epoch, update_freq=args.update_freq, 
-            ch_names=ch_names, is_binary=args.nb_classes == 1, dataloadertype=dataloadertype
+            num_training_steps_per_epoch=num_training_steps_per_epoch, update_freq=args.update_freq,
+            ch_names=ch_names, is_binary=args.nb_classes == 1, dataloadertype=dataloadertype,
+            mixup_fn=mixup_fn,
         )
 
         if args.output_dir and args.save_ckpt:


### PR DESCRIPTION
## Summary
- add configurable jitter, time shift, and channel dropout augmentations for the imagined speech dataset
- expose CLI flags for mixup/cutmix and speech-specific augmentations in the multi-dataset finetuning script
- integrate mixup handling in the training loop with proper logging metrics when soft targets are used

## Testing
- python -m py_compile LaBraM-main/datasets/speech_dataset.py LaBraM-main/run_class_finetuning_multidata.py LaBraM-main/engine_for_finetuning_multidata.py

------
https://chatgpt.com/codex/tasks/task_e_690516e6459c8330a17d24e60eb65b1f